### PR TITLE
Entry delay and non-consecutive zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,33 @@ Added support for Leak and Smoke Detectors.
   ]
 ```
 
+## Non-Consecutive Zones
+If your system has unused zones, simply include a *zoneNumber* integer property on ***each*** zone you have in the config. Make sure you put the property on each zone.
+
+Ex:
+```javascript
+...
+"zones": [
+  {
+    "name": "Front Entry",
+    "type": "door",
+    "partition": 1,
+    "zoneNumber": 1
+  },
+  {
+    "name": "Patio Door",
+    "type": "door",
+    "partition": 1,
+    "zoneNumber": 2
+  },
+  {
+    "name": "Garage Door",
+    "type": "door",
+    "partition": 1,
+    "zoneNumber": 5
+  }
+]
+...
+```
+
 Only DSC panels have been tested thus far.  If you'd like to provide a Honeywell device for testing, I'd be glad to add support for this device and ship it back to you.

--- a/index.js
+++ b/index.js
@@ -65,11 +65,15 @@ function EnvisalinkPlatform(log, config) {
         this.platformPartitionAccessories.push(accessory);
     }
     this.platformZoneAccessories = {};
+    var maxZone = 0;
     if (!config.suppressZoneAccessories) {
         for (var i = 0; i < this.zones.length; i++) {
             var zone = this.zones[i];
             if (zone.type == "motion" || zone.type == "window" || zone.type == "door" || zone.type == "leak" || zone.type == "smoke") {
-                var zoneNum = zone.zoneNumber ? zone.zoneNumber : (i + 1);                
+                var zoneNum = zone.zoneNumber ? zone.zoneNumber : (i + 1);
+                if (zoneNum > maxZone) {
+                    maxZone = zoneNum;
+                }
                 var accessory = new EnvisalinkAccessory(this.log, zone.type, zone, zone.partition, zoneNum);
                 this.platformZoneAccessories['z.' + zoneNum] = accessory;
             } else {
@@ -81,7 +85,7 @@ function EnvisalinkPlatform(log, config) {
     for(var i = 0; i < this.userPrograms.length; i++) {
         var program = this.userPrograms[i];
         if(program.type === "smoke") {
-            var accessory = new EnvisalinkAccessory(this.log, program.type, program, program.partition, this.zones.length + i + 1);
+            var accessory = new EnvisalinkAccessory(this.log, program.type, program, program.partition, maxZone + i + 1);
             this.platformProgramAccessories.push(accessory);
         } else {
             this.log("Unhandled accessory type: " + program.type);

--- a/index.js
+++ b/index.js
@@ -351,7 +351,8 @@ EnvisalinkAccessory.prototype.getAlarmState = function (callback) {
                     status = Characteristic.SecuritySystemCurrentState.AWAY_ARM;
                 }
 
-            } else if (currentState.send == "exitdelay") { //Use the target alarm state during the exit delay.
+            } else if (currentState.send == "exitdelay" || currentState.send == "entrydelay") {
+                //Use the target alarm state during the exit and entrance delays.
                 status = this.lastTargetState;
             }
         }


### PR DESCRIPTION
Hi! I noticed an issue where I couldn’t disarm the system from the Home app during the entrance delay because that status wasn’t handled, so the code reported to the Home app that the alarm was already disarmed. I fixed this by updating to also look for the “entrydelay” event. 

I also modified the code to support non-consecutive zones. My personal setup skips zones 5 and 6. The addition of the maxZone variable is to avoid UUID collisions when the user program accessories are generated (e.g. If you have 10 zones, but 5 and 6 are skipped, the max zone is 10, but the length of the zones array from the config is 8. So the user program will get a “zone number” of 9, which results in a UUID collision). 